### PR TITLE
transform-react-inline-elements visits the AST on JSXElement and tran…

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,14 +2,22 @@
 
 var TRANSLATIONS = require('./translations');
 
+var nestedVisitor = {
+  JSXAttribute: function(node) {
+    console.log(node.node.name.name);
+    if (node.node.name.name in TRANSLATIONS) {
+      node.node.name.name = TRANSLATIONS[node.node.name.name];
+    }
+  },
+};
+
 module.exports = function() {
   return {
     visitor: {
-      JSXAttribute: function(node) {
-        if (node.node.name.name in TRANSLATIONS) {
-          node.node.name.name = TRANSLATIONS[node.node.name.name]
-        }
-      }
-    }
-  }
-}
+      JSXElement: function(path, file) {
+        path.traverse(nestedVisitor);
+      },
+    },
+  };
+};
+


### PR DESCRIPTION
transform-react-inline-elements visits the AST on JSXElement and transforms it such that react-html-attrs JSXAttribute is never visited. To remedy this react-html-attrs needs to visit JSXElements so the attributes are visited.

The code has been modified to make react-html-attrs visit on JSXElement, and then uses Babel's nested visitors to transform the JSXAttribute as needed.

fixes #3
closes babel/babel#5219
